### PR TITLE
Integrate JSCS linter with Webpack using `jscs-loader`

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,0 +1,4 @@
+{
+    "esnext": true,
+    "preset": "airbnb",
+}

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "karma-phantomjs-launcher": "^0.2.1",
     "karma-webpack": "^1.7.0",
     "mocha": "^2.2.5",
+    "jscs": "^2.1.0",
+    "jscs-loader": "^0.2.0",
     "react": "^0.13.3",
     "style-loader": "^0.12.3",
     "webpack": "^1.11.0"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,9 +6,12 @@ module.exports = {
   },
   devtool: 'source-map',
   module: {
+    preloaders: [
+      { test: /\.js$/, loader: 'jscs-loader', exclude: /\/(spec|node_modules)/ }
+    ],
     loaders: [
       { test: /\.jsx?$/, loader: 'babel', exclude: /(node_modules)/ },
       { test: /\.css$/, loaders: ['style', 'css'], exclude: /(node_modules)/ }
     ]
   }
-}
+};


### PR DESCRIPTION
I've integrated the JSCS Linter with webpack using this loader: https://github.com/unindented/jscs-loader; Integrating the JSCS in your text-editor or using it with CLI will improve the code consistency across all projects. I've included the airbnb preset, but it can be modified as we wish.