### PR TITLE
Add autoprefixer as postcss plugin

### DIFF
--- a/browserlist
+++ b/browserlist
@@ -1,0 +1,3 @@
+> 5% in GB
+last 2 versions
+ie > 8

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "description": "A dummy project on how to integrate React and Webpack in a Web project",
   "devDependencies": {
+    "autoprefixer": "^5.2.0",
     "babel-core": "^5.8.22",
     "babel-loader": "^5.3.2",
     "chai": "^3.2.0",
@@ -19,6 +20,7 @@
     "karma-webpack": "^1.7.0",
     "mocha": "^2.2.5",
     "node-sass": "3.2.0",
+    "postcss-loader": "^0.6.0",
     "react": "^0.13.3",
     "react-hot-loader": "^1.2.8",
     "sass-loader": "^2.0.0",

--- a/src/book/heading.scss
+++ b/src/book/heading.scss
@@ -1,6 +1,7 @@
 @import '../colour/colours.scss';
 
 h1 {
+  display: flex;
   &.blue {
     color: $blue;
   }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,6 @@
 var path = require('path');
 var webpack = require('webpack');
+var autoprefixer = require('autoprefixer');
 
 module.exports = {
   entry: [
@@ -31,11 +32,12 @@ module.exports = {
       },
       {
         test: /\.scss$/,
-        loaders: ['style', 'css', 'sass'],
+        loaders: ['style', 'css', 'postcss', 'sass'],
         exclude: /(node_modules)/
       }
     ]
   },
+  postcss: [autoprefixer],
   devtool: 'source-map',
   devServer: {
     contentBase: 'http://localhost:5001'


### PR DESCRIPTION
Resolves #7 
* postcss-loader and autoprefixer packages
* browserlist file to define supported browsers
* prefix-less `flex` property added to heading to demonstrate